### PR TITLE
Fix showcase image responsivity

### DIFF
--- a/themes/nusantara/layouts/showcase/single.html
+++ b/themes/nusantara/layouts/showcase/single.html
@@ -24,7 +24,7 @@
         <div class="container">
             <div class="columns is-multiline is-mobile">
                 {{ range .Site.Data.showcase }}
-                <div class="column is-6-mobile is-4-tablet is-3-desktop">
+                <div class="column is-12-mobile is-12-tablet is-3-desktop">
                     <div class="box">
                         <div class="box-body has-text-centered">
                             <a href="https://{{ .domain }}" target="_blank">


### PR DESCRIPTION
The Ipad Pro size has a desktop size so it doesn't respond to tablet size